### PR TITLE
"introduce postgres to homelab"

### DIFF
--- a/helm/helmfile.yaml
+++ b/helm/helmfile.yaml
@@ -41,7 +41,8 @@ releases:
     namespace: pihole-system
     chart: bitnami/external-dns
     version: 8.3.8
-    values: [./values/externaldns.values.yaml]
+    values:
+      - ./values/externaldns.values.yaml
   # Postgres DB
   - name: postgres
     namespace: postgresql-system

--- a/helm/helmfile.yaml
+++ b/helm/helmfile.yaml
@@ -1,3 +1,4 @@
+---
 repositories:
   - name: longhorn
     url: https://charts.longhorn.io
@@ -16,13 +17,11 @@ releases:
     namespace: longhorn-system
     chart: longhorn/longhorn
     version: 1.7.1
-
   # Load Balancer
   - name: metallb
     namespace: metallb-system
     chart: metallb/metallb
     version: 0.14.8
-
   # Pihole
   - name: pihole
     namespace: pihole-system
@@ -30,7 +29,6 @@ releases:
     version: 2.26.1
     values:
       - ./values/pihole.values.yaml
-
   # nginx Ingress for Local Network
   - name: ingress-nginx-internal
     namespace: nginx-system
@@ -38,11 +36,15 @@ releases:
     version: 4.11.2
     values:
       - ./values/nginx-internal.values.yaml
-
   # Automatic DNS for Pihole
   - name: externaldns-pihole
     namespace: pihole-system
     chart: bitnami/external-dns
     version: 8.3.8
-    values:
-      - ./values/externaldns.values.yaml
+    values: [./values/externaldns.values.yaml]
+  # Postgres DB
+  - name: postgres
+    namespace: postgresql-system
+    chart: bitnami/postgresql
+    version: 16.4.5
+    values: [./values/postgresql.values.yaml]

--- a/helm/values/externaldns.values.yaml
+++ b/helm/values/externaldns.values.yaml
@@ -1,6 +1,7 @@
+---
 provider: pihole
 policy: upsert-only
-txtOwnerId: "homelab"
+txtOwnerId: homelab
 pihole:
   server: http://pihole-web.pihole-system.svc.cluster.local
 extraEnvVars:
@@ -11,6 +12,5 @@ extraEnvVars:
         key: password
 serviceAccount:
   create: true
-  name: "external-dns"
-ingressClassFilters:
-  - nginx-internal
+  name: external-dns
+ingressClassFilters: [nginx-internal]

--- a/helm/values/postgresql.values.yaml
+++ b/helm/values/postgresql.values.yaml
@@ -1,0 +1,21 @@
+---
+architecture: replication
+primary:
+  name: lab-primary
+  service:
+    type: LoadBalancer
+    ports:
+      postgresql: 5432
+  persistence:
+    enabled: true
+    volumeName: data
+    accessModes: [ReadWriteOnce]
+    size: 10Gi
+readReplicas:
+  name: lab-read
+  service:
+    type: LoadBalancer
+    ports:
+      postgresql: 5432
+  persistence:
+    enabled: true

--- a/kustomize/metallb/pool.yaml
+++ b/kustomize/metallb/pool.yaml
@@ -5,14 +5,12 @@ metadata:
   name: pool
   namespace: metallb-system
 spec:
-  addresses:
-    - 192.168.1.192/26
+  addresses: [192.168.1.192/26]
 ---
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
-  name: pool
+  name: homelab
   namespace: metallb-system
 spec:
-  ipAddressPools:
-    - pool
+  ipAddressPools: [pool]


### PR DESCRIPTION
This PR contains the following changes:
- change l2 advertisement from metallb from "pool" to "homelab"
- lint existing values files
- add postgres deployment to helmfile
- add postgres values to values collection

